### PR TITLE
Point to new tmpim-owned repos

### DIFF
--- a/content/examples/klua/installing-klua.md
+++ b/content/examples/klua/installing-klua.md
@@ -10,7 +10,7 @@ lastmodifierdisplayname = "Drew Lemmy"
 lastmodifieremail = "drew@lemmmy.pw"
 +++
 
-The recommended Krist API for Lua is [k.lua](https://github.com/justync7/k.lua) by [Justyn](https://github.com/justync7). This API makes use of [r.lua](https://github.com/justync7/r.lua), [w.lua](https://github.com/justync7/w.lua) and [Jua](https://github.com/justync7/Jua) to make the Krist API a breeze to interact with. You will also need the [JSON API by ElvishJerricco](http://www.computercraft.info/forums2/index.php?/topic/5854-json-api-v201-for-computercraft/) to create and parse the JSON objects required by the Krist API.
+The recommended Krist API for Lua is [k.lua](https://github.com/tmpim/k.lua) by [tmpim](https://github.com/tmpim). This API makes use of [r.lua](https://github.com/tmpim/r.lua), [w.lua](https://github.com/tmpim/w.lua) and [Jua](https://github.com/tmpim/Jua) to make the Krist API a breeze to interact with. You will also need the [JSON API by ElvishJerricco](http://www.computercraft.info/forums2/index.php?/topic/5854-json-api-v201-for-computercraft/) to create and parse the JSON objects required by the Krist API.
 
 ## Installing k.lua and dependencies
 There is a simple script to download + install k.lua and all its dependencies. It can be used in one of two ways.
@@ -22,7 +22,7 @@ pastebin run 4ddNhMYd
 
 ### wget
 ```
-wget https://raw.githubusercontent.com/justync7/k.lua/master/kstrap.lua kstrap.lua
+wget https://raw.githubusercontent.com/tmpim/k.lua/master/kstrap.lua kstrap.lua
 kstrap.lua
 rm kstrap.lua
 ```

--- a/content/examples/klua/using-klua.md
+++ b/content/examples/klua/using-klua.md
@@ -56,15 +56,15 @@ end)
 ### Supported API calls
 K.lua currently supports the following API calls:
 
-- [`address(address)`](https://github.com/justync7/k.lua/blob/master/k.lua#L48) ([api docs](http://krist.ceriat.net/docs/#api-AddressGroup-GetAddress)) - Gets information about an address, such as its balance
-- [`addressTransactions(address, limit, offset)`](https://github.com/justync7/k.lua/blob/master/k.lua#L55) ([api docs](http://krist.ceriat.net/docs/#api-AddressGroup-GetAddressTransactions)) - Gets recent transactions by an address
-- [`addressNames(address)`](https://github.com/justync7/k.lua/blob/master/k.lua#61) ([api docs](http://krist.ceriat.net/docs/#api-AddressGroup-GetAddressNames)) - Gets names owned by an address
-- [`addresses(limit, offset)`](https://github.com/justync7/k.lua/blob/master/k.lua#67) ([api docs](http://krist.ceriat.net/docs/#api-AddressGroup-GetAddresses)) - List all addresses
-- [`rich(limit, offset)`](https://github.com/justync7/k.lua/blob/master/k.lua#73) ([api docs](http://krist.ceriat.net/docs/#api-AddressGroup-GetRichAddresses)) - List the addresses with the highest balance
-- [`transactions(limit, offset)`](https://github.com/justync7/k.lua/blob/master/k.lua#79) ([api docs](http://krist.ceriat.net/docs/#api-TransactionGroup-GetTransactions)) - List all transactions
-- [`latestTransactions(limit, offset)`](https://github.com/justync7/k.lua/blob/master/k.lua#85) ([api docs](http://krist.ceriat.net/docs/#api-TransactionGroup-GetLatestTransactions)) - List all recent transactions
-- [`transaction(transactionID)`](https://github.com/justync7/k.lua/blob/master/k.lua#91) ([api docs](http://krist.ceriat.net/docs/#api-TransactionGroup-GetTransaction)) - Get information about a single transaction
-- [`makeTransaction(privatekey, to, amount, metadata)`](https://github.com/justync7/k.lua/blob/master/k.lua#97) ([api docs](http://krist.ceriat.net/docs/#api-TransactionGroup-MakeTransaction)) - Make a transaction
+- [`address(address)`](https://github.com/tmpim/k.lua/blob/master/k.lua#L48) ([api docs](http://krist.ceriat.net/docs/#api-AddressGroup-GetAddress)) - Gets information about an address, such as its balance
+- [`addressTransactions(address, limit, offset)`](https://github.com/tmpim/k.lua/blob/master/k.lua#L55) ([api docs](http://krist.ceriat.net/docs/#api-AddressGroup-GetAddressTransactions)) - Gets recent transactions by an address
+- [`addressNames(address)`](https://github.com/tmpim/k.lua/blob/master/k.lua#61) ([api docs](http://krist.ceriat.net/docs/#api-AddressGroup-GetAddressNames)) - Gets names owned by an address
+- [`addresses(limit, offset)`](https://github.com/tmpim/k.lua/blob/master/k.lua#67) ([api docs](http://krist.ceriat.net/docs/#api-AddressGroup-GetAddresses)) - List all addresses
+- [`rich(limit, offset)`](https://github.com/tmpim/k.lua/blob/master/k.lua#73) ([api docs](http://krist.ceriat.net/docs/#api-AddressGroup-GetRichAddresses)) - List the addresses with the highest balance
+- [`transactions(limit, offset)`](https://github.com/tmpim/k.lua/blob/master/k.lua#79) ([api docs](http://krist.ceriat.net/docs/#api-TransactionGroup-GetTransactions)) - List all transactions
+- [`latestTransactions(limit, offset)`](https://github.com/tmpim/k.lua/blob/master/k.lua#85) ([api docs](http://krist.ceriat.net/docs/#api-TransactionGroup-GetLatestTransactions)) - List all recent transactions
+- [`transaction(transactionID)`](https://github.com/tmpim/k.lua/blob/master/k.lua#91) ([api docs](http://krist.ceriat.net/docs/#api-TransactionGroup-GetTransaction)) - Get information about a single transaction
+- [`makeTransaction(privatekey, to, amount, metadata)`](https://github.com/tmpim/k.lua/blob/master/k.lua#97) ([api docs](http://krist.ceriat.net/docs/#api-TransactionGroup-MakeTransaction)) - Make a transaction
 
 ### Making a request
 To make a request, you need to `await()` the API call, for example:

--- a/content/krist-api/wallet-formats.md
+++ b/content/krist-api/wallet-formats.md
@@ -22,7 +22,7 @@ It applies the following transformations:
 - Append `-000`
 
 #### k.lua
-If you are using [k.lua](https://github.com/justync7/k.lua/), you can use `k.toKristWalletFormat(privatekey)`.
+If you are using [k.lua](https://github.com/tmpim/k.lua/), you can use `k.toKristWalletFormat(privatekey)`.
 
 #### Plain lua
 This requires a [sha256 API](http://www.computercraft.info/forums2/index.php?/topic/8169-sha-256-in-pure-lua/). Example code to perform these operations would look like this:


### PR DESCRIPTION
This just points most of the docs to the proper non-redirect repos, and changes the creator of Jua from "Justyn" to "tmpim" to properly reflect the project ownership.